### PR TITLE
Tweaked icon alignment in links and permissions

### DIFF
--- a/src/main/kotlin/nya/kitsunyan/foxydroid/screen/ProductAdapter.kt
+++ b/src/main/kotlin/nya/kitsunyan/foxydroid/screen/ProductAdapter.kt
@@ -562,7 +562,7 @@ class ProductAdapter(private val callbacks: Callbacks, private val columns: Int)
       }
       currentItem is Item.LinkItem && nextItem is Item.LinkItem ||
         currentItem is Item.PermissionsItem && nextItem is Item.PermissionsItem -> {
-        configuration.set(true, false, context.resources.sizeScaled(72), 0)
+        configuration.set(true, false, context.resources.sizeScaled(56), 0)
       }
       currentItem is Item.SwitchItem && nextItem is Item.SwitchItem ||
         currentItem is Item.ReleaseItem && nextItem is Item.ReleaseItem -> {

--- a/src/main/res/layout/link_item.xml
+++ b/src/main/res/layout/link_item.xml
@@ -16,6 +16,7 @@
     android:scaleType="centerInside"
     android:tint="?android:attr/textColorSecondary"
     android:tintMode="src_in"
+    android:layout_gravity="center"
     tools:ignore="ContentDescription" />
 
   <LinearLayout
@@ -23,7 +24,7 @@
     android:layout_height="wrap_content"
     android:layout_weight="1"
     android:orientation="vertical"
-    android:layout_marginStart="32dp"
+    android:layout_marginStart="16dp"
     android:paddingTop="16dp"
     android:paddingBottom="16dp">
 

--- a/src/main/res/layout/permissions_item.xml
+++ b/src/main/res/layout/permissions_item.xml
@@ -16,6 +16,7 @@
     android:scaleType="centerInside"
     android:tint="?android:attr/textColorSecondary"
     android:tintMode="src_in"
+    android:layout_gravity="center"
     tools:ignore="ContentDescription" />
 
   <TextView
@@ -23,7 +24,7 @@
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_weight="1"
-    android:layout_marginStart="32dp"
+    android:layout_marginStart="16dp"
     android:paddingTop="16dp"
     android:paddingBottom="16dp"
     android:textColor="?android:attr/textColorPrimary"


### PR DESCRIPTION
I've tweak the icon alignment in links and permission items to be vertically and horizontally centered. This was the thing that seemed really odd to me when I first tried this app. I also decreased the margin since it looked a bit weird while it was centered.

This is just my opinion. I thought I would tweak it for myself and publish the changes here. 